### PR TITLE
Temporary closures: align README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,6 @@ We are trying to make the data portable across a range of devices, some of which
 
 This API is for weekly recovery meetings.
 
-#### What about temporary cancellations or closures?
-
-This API is for current meetings. If a meeting has closed, even temporarily, it should be removed from the feed and restored once it has resumed meeting.
-
 #### Want to build your own JavaScript meeting finder from
 
 There are lots of ways to do it, but one way is using jQuery ([jQuery demo](jquery-demo/demo.html)).


### PR DESCRIPTION
Make README consistent with spec regarding temporary closures. Now that the `TC` field is supported in meeting types, meetings can be marked as temporarily closed.