### PR TITLE
Add potential new fields for discussion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,15 @@ The JSON file is expected to contain a simple array of meetings. [Here is an exa
 
 `region` is an optional string that represents a geographical subset of meeting locations. Usually this is a neighborhood or city. District numbers are discouraged because they require special program knowledge to be understood.
 
-`venmo` is an optional string and should be a valid Venmo handle, eg @FFG-Group. This is understood to be the address for 7th Tradition contributions to the group, and not any other entity.
+`status` is an optional string which can be `active`, `suspended`, `online-only`, or `inactive`. If `status` is not provided, meetings will be assumed to be `active`. Other types can be used by independent front ends, but these four seem to be ones most regions will use.
 
-`video_conference_url` is an optional URL to a specific public videoconference meeting. This should be a common videoconferencing service such as Zoom or Google Hangouts. It should launch directly into the meeting, without requiring the user to type a meeting ID, password, or be invited to join beforehand. Online meetings should still have a physical address, and an optional meeting type of `TC` (Temporary Closure). This spec is still for geographic meetings; a true online-only spec is in the planning stages.
+`payment_venmo` is an optional string and should be a valid Venmo handle, eg @FFG-Group. This is understood to be the address for 7th Tradition contributions to the group, and not any other entity.
+
+`payment_paypal` is an optional string and should be a valid PayPal email address, such as myhomegroup@gmail.com. This is understood to be the address for 7th Tradition contributions to the group, and not any other entity.
+
+`video_conference_url` is an optional URL to a specific public videoconference meeting. This should be a common videoconferencing service such as Zoom, BlueJeans, Skype, or Google Hangouts. It should launch directly into the meeting, without requiring the user to type a meeting ID, password, or be invited to join beforehand. Online meetings should still have a physical address, and an optional meeting type of `TC` (Temporary Closure). This spec is still for geographic meetings; a true online-only spec is in the planning stages.
+
+`video_conference_dial_in` is an optional text field to include a phone number and meeting code to join via telephone.URL to a specific public videoconference meeting. This should be a common videoconferencing service such as Zoom or Google Hangouts. It should launch directly into the meeting, without requiring the user to type a meeting ID, password, or be invited to join beforehand. Online meetings should still have a physical address, and an optional meeting type of `TC` (Temporary Closure). This spec is still for geographic meetings; a true online-only spec is in the planning stages.
 
 ## Common Questions & Concerns
 


### PR DESCRIPTION
Howdy @joshreisner and @tintinnabulate, I hope you are both staying safe.

I've had to move quickly to accommodate changes in Philly, and I'm sure you're both probably doing the same. I'm trying to think long-term. A few things have become apparent:

- We needed a way for meetings to be marked suspended / temp closed.
- We needed a way for meetings to become online-only, even if temporarily.
- Meetings may want to keep things like a backup online URL for emergencies.
- Meetings needed a dial-in option for people without smart phones / computers.

To this end, it seemed to make sense to introduce a `status` field, rather than overloading meeting types. To avoid confusion with `Open` and `Closed` meeting types, we're using `Active` and `Inactive`, and have added `Suspended` (language adopted by GSO and NY Intergroup) and `Online Only`.

We're also suggesting adding or changing these fields:

`video_conference_url` - keep as is.
`video_conference_dial_in` - text field for dial-in info to the Zoom/BlueJeans/Hangouts/Skype.
`payment_venmo` - rename the field so we can have multiple payment types in alpha order.
`payment_paypal` - a bunch of our groups use PayPal (for old folks) and Venmo (for young folks).

This will allow us to tag meetings as Online Only - for now - and return them to be Active once the emergency passes, while allowing them to retain their online meeting information. Some meetings will want to continue streaming, while others will keep it "in case of emergency."

I'm not saying this is the end-all, be-all way to do things, but this is where I ended up when scrambling to get things working, and it seems to be working well so far. We've pre-pended meeting titles with `ONLINE ONLY` or `SUSPENDED` to make it abundantly clear. You can see it here:

https://www.aasepia.org/?day=any&search=online

What do y'all think?