### PR TITLE
adding feedback_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ The JSON file is expected to contain a simple array of meetings. [Here is an exa
 
 `conference_phone_notes` is an optional string with metadata about the `conference_phone` (eg a numeric meeting password or other user instructions). This field is not yet supported by the Meeting Guide app.
 
+`feedback_url` is an optional string that [TSML-UI](https://github.com/code4recovery/tsml-ui) uses for meeting feedback links. These could be local links, eg `/feedback?meeting=meeting-slug-1`, remote links, eg `https://typeform.com/to/23904203?meeting=meeting-slug-1`, or email links, eg `mailto:webservant@domain.org?subject=meeting-slug-1`.
+
 ## Common Questions & Concerns
 
 #### We use different meeting codes!


### PR DESCRIPTION
By San Francisco Intergroup's request, TSML-UI looks for an (until now) undocumented `feedback_url` in the JSON to add a "Update Meeting Info" button similar to the feedback form in TSML.

This PR seeks to add documentation for that key and make it an official part of the spec.

San Francisco's JSON feed: https://airtable-json.aasfmarin.org

Example meeting: https://aasfmarin.org/meetings?meeting=larkspur-saturday-morning-12-and-12-748