### PR TITLE
fix two type translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ Also when adding a custom type, it's wise to stay away from any [ISO 369 languag
 |`FF`|Fragrance Free|Sin fragancia|Sans parfum|香水なし|Geen parfum|Sem Perfumes|Bez vône|Parfym Fritt|
 |`FR`|French|Francés|Français|フランス語|Frans|Francês|Francúzsky|Franska|
 |`G`|Gay|Gay|Gai|ゲイ|Homo|Gay|Gay|Gay|
-|`GR`|Grapevine|La Viña|Grapevine|グレープバイン|Wijnstok|Grapevine|Grapevine|Grapevine|
+|`GR`|Grapevine|La Viña|La Vigne|グレープバイン|Wijnstok|Grapevine|Grapevine|Grapevine|
 |`H`|Birthday|Cumpleaños|Anniversaire|バースデー|Verjaardag|Aniversário|Narodeniny|Födelsedag|
 |`HE`|Hebrew|Hebreo|Hébreu|ヘブライ語|Hebreeuws|Hebreu|Hebrejské|Hebreiska|
 |`HI`|Hindi|Hindi|Hindi|ヒンディー語|Hindi|Hindi|Hindi|Hindi|
@@ -434,7 +434,7 @@ Also when adding a custom type, it's wise to stay away from any [ISO 369 languag
 |`TR`|Tradition Study|Estudio de tradicion|Étude des Traditions|伝統|Traditie Studie|Estudo de Tradições|Tradičné štúdium|Traditionsmöte|
 |`TUR`|Turkish|Turco|Turc|トルコ語|Turks|Turco|Turecký|Turkiska|
 |`UK`|Ukrainian|Ucraniano|Ukrainien|ウクライナ語|Oekraïens|Ucraniano|Ukrajinské|Ukrainska|
-|`W`|Women|Mujer|Femmes|女性|Vrouwen|Mulheres|Ženy|Kvinnomöte|
+|`W`|Women|Mujeres|Femmes|女性|Vrouwen|Mulheres|Ženy|Kvinnomöte|
 |`X`|Wheelchair Access|Acceso en silla de ruedas|Accès aux fauteuils roulants|車いすアクセス|Toegankelijk voor rolstoelgebruikers|Acesso a Cadeiras de Rodas|Prístup pre vozíčkarov|Handikappanpassat|
 |`XB`|Wheelchair-Accessible Bathroom|Baño accesible para sillas de ruedas|Toilettes accessibles aux fauteuils roulants|車いす使用者用トイレ|Rolstoeltoegankelijke badkamer|WC com Acesso a Cadeiras de Rodas|Bezbariérová kúpeľňa|Handikappanpassad WC|
 |`XT`|Cross Talk Permitted|Se permite opinar|Conversation croisée permise|クロストーク可能|Cross-sharen toegestaan|Prtilhas Cruzadas Permitidas|Cross Talk povolený|Kommentarer Tilltåtna|

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,21 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "fc971fe58e55bbc06a537c33b69d2a0e",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.4",
+        "ext-json": "*"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/data/types.json
+++ b/data/types.json
@@ -322,7 +322,7 @@
   "GR": {
     "en": "Grapevine",
     "es": "La Viña",
-    "fr": "Grapevine",
+    "fr": "La Vigne",
     "ja": "グレープバイン",
     "nl": "Wijnstok",
     "pt": "Grapevine",
@@ -821,7 +821,7 @@
   },
   "W": {
     "en": "Women",
-    "es": "Mujer",
+    "es": "Mujeres",
     "fr": "Femmes",
     "ja": "女性",
     "nl": "Vrouwen",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@code4recovery/spec",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@code4recovery/spec",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4recovery/spec",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "The goal of the Meeting Guide API is help sync information about AA meetings. It was developed for the Meeting Guide app, but it is non-proprietary and other systems are encouraged to make use of it.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/types.php
+++ b/src/types.php
@@ -357,7 +357,7 @@ return (object) array(
   (object) array(
      'en' => 'Grapevine',
      'es' => 'La Viña',
-     'fr' => 'Grapevine',
+     'fr' => 'La Vigne',
      'ja' => 'グレープバイン',
      'nl' => 'Wijnstok',
      'pt' => 'Grapevine',
@@ -906,7 +906,7 @@ return (object) array(
    'W' => 
   (object) array(
      'en' => 'Women',
-     'es' => 'Mujer',
+     'es' => 'Mujeres',
      'fr' => 'Femmes',
      'ja' => '女性',
      'nl' => 'Vrouwen',

--- a/src/types.ts
+++ b/src/types.ts
@@ -322,7 +322,7 @@ export const types = {
   GR: {
     en: "Grapevine",
     es: "La Viña",
-    fr: "Grapevine",
+    fr: "La Vigne",
     ja: "グレープバイン",
     nl: "Wijnstok",
     pt: "Grapevine",
@@ -821,7 +821,7 @@ export const types = {
   },
   W: {
     en: "Women",
-    es: "Mujer",
+    es: "Mujeres",
     fr: "Femmes",
     ja: "女性",
     nl: "Vrouwen",


### PR DESCRIPTION
per an email to app support, our translation for Women in Spanish should be Mujeres, and our translation for Grapevine in French should be La Vigne

<img width="844" alt="Screenshot 2025-06-19 at 7 31 31 AM" src="https://github.com/user-attachments/assets/72ad46df-e030-46a5-8783-11b1b8b1a343" />

adds composer.lock to the repo
bumps package.json